### PR TITLE
Add session management

### DIFF
--- a/lambda/Sources/APILambda/TorpinServiceLambda.swift
+++ b/lambda/Sources/APILambda/TorpinServiceLambda.swift
@@ -1,6 +1,7 @@
 import AWSLambdaRuntime
 import AWSLambdaEvents
 import Common
+import AWSDynamoDB
 import Foundation
 import HTTPTypes
 
@@ -16,16 +17,20 @@ struct TorpinServiceLambda: LambdaHandler {
     typealias In = APIGatewayRequest
     typealias Out = APIGatewayResponse
 
-    let steamClient: SteamClient
+    let region = "us-west-1"
+    let sessionManager: SessionManager
 
     init(context: LambdaInitializationContext) async throws {
         LogManager.initialize(from: context)
-        self.steamClient = SteamClient()
+        let config = try await DynamoDBClient.DynamoDBClientConfiguration()
+        config.region = self.region
+        let client = DynamoDBClient(config: config)
+        self.sessionManager = SessionManager(client: client)
     }
 
     func handle(_ event: In, context: LambdaContext) async throws -> Out {
         LogManager.shared.info("Event received: \(event)")
-        let isBrianTorpin = try await steamClient.isBrianTorpin()
+        let isBrianTorpin = try await sessionManager.hasActiveSession()
         let result = TorpinResult(isBrianTorpin: isBrianTorpin)
         return APIGatewayResponse(
             statusCode: HTTPResponse.Status(200),

--- a/lambda/Sources/Common/Model/RecordType.swift
+++ b/lambda/Sources/Common/Model/RecordType.swift
@@ -1,3 +1,4 @@
 enum RecordType: String, Codable {
     case torpinRecord
+    case sessionRecord
 }

--- a/lambda/Sources/Common/Model/SessionRecord.swift
+++ b/lambda/Sources/Common/Model/SessionRecord.swift
@@ -1,0 +1,55 @@
+import AWSDynamoDB
+import Foundation
+
+public struct SessionRecord: Codable {
+    var endDate: Date?
+    let recordType: RecordType
+    let startDate: Date
+
+    public init(startDate: Date, endDate: Date? = nil) {
+        self.startDate = startDate
+        self.endDate = endDate
+        self.recordType = .sessionRecord
+    }
+
+    init(withItem item: [String:DynamoDBClientTypes.AttributeValue]) throws  {
+        let iso = ISO8601DateFormatter()
+        guard let dateAttribute = item["startDate"],
+              let recordTypeAttribute = item["recordType"] else {
+            throw RecordError.ItemNotFound
+        }
+        if case .s(let rawValue) = dateAttribute, let date = iso.date(from: rawValue) {
+            self.startDate = date
+        } else {
+            throw RecordError.InvalidAttributes
+        }
+
+        if case .s(let rawValue) = recordTypeAttribute, let parsedType = RecordType(rawValue: rawValue) {
+            self.recordType = parsedType
+        } else {
+            throw RecordError.InvalidAttributes
+        }
+
+        if let endDateAttribute = item["endDate"] {
+            if case .s(let rawValue) = endDateAttribute, let end = iso.date(from: rawValue) {
+                self.endDate = end
+            } else {
+                throw RecordError.InvalidAttributes
+            }
+        } else {
+            self.endDate = nil
+        }
+    }
+
+    func getAsItem() async throws -> [Swift.String:DynamoDBClientTypes.AttributeValue]  {
+        let iso = ISO8601DateFormatter()
+        var item: [Swift.String:DynamoDBClientTypes.AttributeValue] = [
+            "startDate": .s(iso.string(from: startDate)),
+            "recordType": .s(self.recordType.rawValue),
+        ]
+        if let endDate {
+            item["endDate"] = .s(iso.string(from: endDate))
+        }
+        return item
+    }
+}

--- a/lambda/Sources/Common/Session/SessionManager.swift
+++ b/lambda/Sources/Common/Session/SessionManager.swift
@@ -1,0 +1,62 @@
+import AWSDynamoDB
+import Foundation
+
+public actor SessionManager {
+    private let tableName = "Torpin"
+    private let client: DynamoDBClient
+
+    public init(client: DynamoDBClient) {
+        self.client = client
+    }
+
+    public func hasActiveSession() async throws -> Bool {
+        return try await getActiveSession() != nil
+    }
+
+    public func createSession(at date: Date) async throws {
+        let record = SessionRecord(startDate: date)
+        let item = try await record.getAsItem()
+        let input = PutItemInput(item: item, tableName: tableName)
+        _ = try await client.putItem(input: input)
+        LogManager.shared.info("Created session starting at \(date)")
+    }
+
+    public func closeActiveSession(at date: Date) async throws {
+        guard let session = try await getActiveSession() else { return }
+        let iso = ISO8601DateFormatter()
+        let key: [String:DynamoDBClientTypes.AttributeValue] = [
+            "recordType": .s(RecordType.sessionRecord.rawValue),
+            "startDate": .s(iso.string(from: session.startDate))
+        ]
+        let values: [String:DynamoDBClientTypes.AttributeValue] = [
+            ":endDate": .s(iso.string(from: date))
+        ]
+        let input = UpdateItemInput(
+            expressionAttributeValues: values,
+            key: key,
+            tableName: tableName,
+            updateExpression: "SET endDate = :endDate"
+        )
+        _ = try await client.updateItem(input: input)
+        LogManager.shared.info("Closed session starting at \(session.startDate)")
+    }
+
+    private func getActiveSession() async throws -> SessionRecord? {
+        let values: [String:DynamoDBClientTypes.AttributeValue] = [
+            ":record": .s(RecordType.sessionRecord.rawValue)
+        ]
+        let input = QueryInput(
+            expressionAttributeValues: values,
+            keyConditionExpression: "recordType = :record",
+            tableName: tableName
+        )
+        let output = try await client.query(input: input)
+        let items = output.items ?? []
+        for item in items {
+            if item["endDate"] == nil {
+                return try SessionRecord(withItem: item)
+            }
+        }
+        return nil
+    }
+}

--- a/lambda/Sources/EventHandlerLambda/EventHandler.swift
+++ b/lambda/Sources/EventHandlerLambda/EventHandler.swift
@@ -13,6 +13,7 @@ struct EventHandlerLambda: LambdaHandler {
 
     let steamClient: SteamClient
     let recordTable: RecordTable
+    let sessionManager: SessionManager
     
     init(context: LambdaInitializationContext) async throws {
         LogManager.initialize(from: context)
@@ -21,13 +22,26 @@ struct EventHandlerLambda: LambdaHandler {
         config.region = self.region
         let client = DynamoDBClient(config: config)
         self.recordTable = RecordTable(client: client)
+        self.sessionManager = SessionManager(client: client)
     }
     
     func handle(_ event: In, context: LambdaContext) async throws -> Out {
         LogManager.shared.info("Event triggered")
-        let torpin = try await steamClient.isBrianTorpin()
+        async let torpin = steamClient.isBrianTorpin()
+        async let activeSession = sessionManager.hasActiveSession()
+        let (torpin, hasActive) = try await (torpin, activeSession)
         let torpinRecord = TorpinRecord(date: Date(), torpin: torpin)
         _ = try await recordTable.add(torpinRecord)
+
+        switch (torpin, hasActive) {
+        case (true, false):
+            try await sessionManager.createSession(at: torpinRecord.date)
+        case (false, true):
+            try await sessionManager.closeActiveSession(at: torpinRecord.date)
+        default:
+            break
+        }
+
         LogManager.shared.info("Brian is torpin: \(torpin)")
     }
 }


### PR DESCRIPTION
## Summary
- track sessions in DynamoDB via SessionManager
- store new SessionRecord model type
- update event handler lambda to open/close sessions
- update API lambda to respond based on active session
- rename SessionRecord date field to `startDate`
- run steam and session queries in parallel when handling events

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-server/swift-aws-lambda-events.git)*