### PR TITLE
Improve JSON encoding for API Lambda

### DIFF
--- a/lambda/Package.swift
+++ b/lambda/Package.swift
@@ -43,6 +43,11 @@ let package = Package(
                 .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ],
             path: "Sources/Common"
+        ),
+        .testTarget(
+            name: "APILambdaTests",
+            dependencies: ["TorpinServiceLambda"],
+            path: "Tests/APILambda"
         )
     ]
 )

--- a/lambda/Sources/APILambda/TorpinServiceLambda.swift
+++ b/lambda/Sources/APILambda/TorpinServiceLambda.swift
@@ -26,7 +26,7 @@ struct TorpinServiceLambda: LambdaHandler {
         let result = TorpinResult(isBrianTorpin: isBrianTorpin)
         let bodyData = try JSONEncoder().encode(result)
         let body = String(decoding: bodyData, as: UTF8.self)
-        return APIGatewayResponse(
+        let response = APIGatewayResponse(
             statusCode: HTTPResponse.Status(200),
             headers: [
                 "Access-Control-Allow-Origin": "*",
@@ -34,5 +34,7 @@ struct TorpinServiceLambda: LambdaHandler {
             ],
             body: body
         )
+        LogManager.shared.info("Response: \(response)")
+        return response;
     }
 }

--- a/lambda/Sources/APILambda/TorpinServiceLambda.swift
+++ b/lambda/Sources/APILambda/TorpinServiceLambda.swift
@@ -4,11 +4,8 @@ import Common
 import Foundation
 import HTTPTypes
 
-struct TorpinResult: Codable, CustomStringConvertible {
+struct TorpinResult: Codable {
     let isBrianTorpin: Bool
-    var description: String {
-        return "{\"isBrianTorpin\": \(isBrianTorpin)}"
-    }
 }
 
 @main
@@ -27,9 +24,12 @@ struct TorpinServiceLambda: LambdaHandler {
         LogManager.shared.info("Event received: \(event)")
         let isBrianTorpin = try await steamClient.isBrianTorpin()
         let result = TorpinResult(isBrianTorpin: isBrianTorpin)
+        let bodyData = try JSONEncoder().encode(result)
+        let body = String(decoding: bodyData, as: UTF8.self)
         return APIGatewayResponse(
             statusCode: HTTPResponse.Status(200),
-            body: "\(result)"
+            headers: ["Content-Type": "application/json"],
+            body: body
         )
     }
 }

--- a/lambda/Sources/APILambda/TorpinServiceLambda.swift
+++ b/lambda/Sources/APILambda/TorpinServiceLambda.swift
@@ -28,7 +28,10 @@ struct TorpinServiceLambda: LambdaHandler {
         let body = String(decoding: bodyData, as: UTF8.self)
         return APIGatewayResponse(
             statusCode: HTTPResponse.Status(200),
-            headers: ["Content-Type": "application/json"],
+            headers: [
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "application/json"
+            ],
             body: body
         )
     }

--- a/lambda/Tests/APILambda/TorpinServiceLambdaTests.swift
+++ b/lambda/Tests/APILambda/TorpinServiceLambdaTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import TorpinServiceLambda
+
+final class TorpinServiceLambdaTests: XCTestCase {
+    func testTorpinResultEncoding() throws {
+        let result = TorpinResult(isBrianTorpin: true)
+        let data = try JSONEncoder().encode(result)
+        let json = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(json, "{\"isBrianTorpin\":true}")
+    }
+}
+


### PR DESCRIPTION
## Summary
- use `String(decoding:as:)` to avoid silent failure when converting JSON data
- update unit test for TorpinResult encoding

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_683a2889e33883279a23015fdb95cd3a