### PR TITLE
Add API warm call

### DIFF
--- a/cdk/lib/torpin-stack.ts
+++ b/cdk/lib/torpin-stack.ts
@@ -58,6 +58,7 @@ export class TorpinStack extends Stack {
       environment: {
         STEAM_API_KEY: process.env.STEAM_API_KEY || '',
         STEAM_ID: process.env.STEAM_ID || '',
+        TORPIN_API_URL: 'https://api.isbriantorp.in/v1',
       },
     });
 

--- a/lambda/Sources/EventHandlerLambda/EventHandler.swift
+++ b/lambda/Sources/EventHandlerLambda/EventHandler.swift
@@ -1,6 +1,7 @@
 import AWSDynamoDB
-import AWSLambdaRuntime
 import AWSLambdaEvents
+import AWSLambdaRuntime
+import AsyncHTTPClient
 import Common
 import Foundation
 
@@ -9,10 +10,9 @@ struct EventHandlerLambda: LambdaHandler {
     typealias In = EventBridgeEvent<CloudwatchDetails.Scheduled>
     typealias Out = Void
 
-    let region = "us-west-1"
-
-    let steamClient: SteamClient
     let recordTable: RecordTable
+    let region = "us-west-1"
+    let steamClient: SteamClient
     
     init(context: LambdaInitializationContext) async throws {
         LogManager.initialize(from: context)
@@ -29,5 +29,23 @@ struct EventHandlerLambda: LambdaHandler {
         let torpinRecord = TorpinRecord(date: Date(), torpin: torpin)
         _ = try await recordTable.add(torpinRecord)
         LogManager.shared.info("Brian is torpin: \(torpin)")
+        await Self.warmAPI()
+    }
+
+    static func warmAPI() async {
+        guard let url = ProcessInfo.processInfo.environment["TORPIN_API_URL"] else {
+            LogManager.shared.info("TORPIN_API_URL not set")
+            return
+        }
+
+        var request = HTTPClientRequest(url: url)
+        request.method = .GET
+
+        do {
+            let response = try await HTTPClient.shared.execute(request, timeout: .seconds(5))
+            LogManager.shared.info("Warm API status: \(response.status)")
+        } catch {
+            LogManager.shared.error("Warm API call failed: \(error)")
+        }
     }
 }

--- a/lambda/Tests/EventHandlerLambda/EventHandlerLambdaTests.swift
+++ b/lambda/Tests/EventHandlerLambda/EventHandlerLambdaTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import EventHandlerLambda
+
+final class EventHandlerLambdaTests: XCTestCase {
+    func testWarmAPIWithoutEnv() async {
+        unsetenv("TORPIN_API_URL")
+        await EventHandlerLambda.warmAPI()
+    }
+}


### PR DESCRIPTION
## Summary
- warm the API from the scheduled lambda
- expose API URL to EventHandlerLambda
- add EventHandlerLambda tests

## Testing
- `swift test` *(fails: crypto_ex_data_st has different definitions in different modules)*

------
https://chatgpt.com/codex/tasks/task_b_683bb34ef0888327936d758d3c489ded