### PR TITLE
Fix mobile scroll

### DIFF
--- a/astro/src/layouts/Layout.astro
+++ b/astro/src/layouts/Layout.astro
@@ -2,7 +2,7 @@
   <head>
   <slot name="head" />
   </head>
-  <body style="margin: 0;">
+  <body style="margin: 0; overflow: hidden;">
   <div id="page-root" style="position: relative; height: 100vh;">
     <slot />
   </div>


### PR DESCRIPTION
## Summary
- stop the site from scrolling by hiding overflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f82d4c6a083278060912861bf3bac