### PR TITLE
chore: generate lambda artifacts in CI

### DIFF
--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -23,6 +23,15 @@ jobs:
       - name: Install CDK globally
         run: npm install -g aws-cdk
 
+      - name: Create placeholder lambda artifacts
+        run: |
+          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda
+          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda
+          echo 'placeholder' > lambda/placeholder.txt
+          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda/TorpinServiceLambda.zip lambda/placeholder.txt
+          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda/EventHandlerLambda.zip lambda/placeholder.txt
+          rm lambda/placeholder.txt
+
       - name: Synthesize CDK
         working-directory: ./cdk
         run: npx cdk synth

--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     paths:
       - 'cdk/**'
+  workflow_dispatch:
 
 jobs:
   build-cdk:


### PR DESCRIPTION
## Summary
- remove committed lambda build artifacts
- generate placeholder lambda zips during CDK workflow

## Testing
- `npm --prefix cdk run synth`
- `cd lambda && swift test` *(fails: unable to access GitHub repositories, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5d4c4ad8832baa6cafbb6d8c7d30