### PR TITLE
feat(ci): add manual triggers for PR workflows

### DIFF
--- a/.github/workflows/pr-astro.yaml
+++ b/.github/workflows/pr-astro.yaml
@@ -1,6 +1,7 @@
 name: Build Astro site on PRs
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -1,6 +1,7 @@
 name: Build CDK on PRs
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/pr-lambda.yaml
+++ b/.github/workflows/pr-lambda.yaml
@@ -1,6 +1,7 @@
 name: Build Lambda on PRs
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
## Summary
- allow manual runs for Astro build PR workflow
- allow manual runs for CDK build PR workflow
- allow manual runs for Lambda build PR workflow

## Testing
- `swift test` *(fails: unable to access dependencies, CONNECT tunnel failed 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c05b82d0b8832b8fb55d89546d6ee7