### PR TITLE
Split Swift Dependabot entries for /lambda and /lambda-v2 and rename groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "swift"
-    directories:
-      - "/lambda"
-      - "/lambda-v2"
+    directory: "/lambda"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -31,11 +29,28 @@ updates:
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
     groups:
-      swift-version-updates:
+      swift-v1-version-updates:
         applies-to: version-updates
         patterns:
           - "*"
-      swift-security-updates:
+      swift-v1-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "swift"
+    directory: "/lambda-v2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    groups:
+      swift-v2-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      swift-v2-security-updates:
         applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
### Motivation
- Ensure Dependabot treats Swift packages in `"/lambda"` and `"/lambda-v2"` as separate update targets so updates do not get merged into a single stream.
- Disambiguate group identifiers so version and security updates are tracked independently per Swift package.

### Description
- Replace the combined `directories:` listing for `package-ecosystem: "swift"` with two separate entries using `directory: "/lambda"` and `directory: "/lambda-v2"`.
- Move `schedule`, `open-pull-requests-limit`, and `groups` into each Swift entry so each directory has the same weekly schedule and limits.
- Rename group keys from `swift-version-updates`/`swift-security-updates` to `swift-v1-version-updates`/`swift-v1-security-updates` and `swift-v2-version-updates`/`swift-v2-security-updates` to avoid collisions.
- Leave the existing `npm` update configuration unchanged.

### Testing
- Ran YAML validation with `yamllint` against `.github/dependabot.yml` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb848308c0832bb106d00a9ae2f38b)