### PR TITLE
[codex] Migrate Lambda runtimes to AL2023

### DIFF
--- a/cdk/lib/torpin-stack.ts
+++ b/cdk/lib/torpin-stack.ts
@@ -22,7 +22,7 @@ export class TorpinStack extends Stack {
     });
 
     const apiLambda = new Function(this, 'TorpinApi', {
-      runtime: Runtime.PROVIDED_AL2,
+      runtime: Runtime.PROVIDED_AL2023,
       architecture: Architecture.ARM_64,
       memorySize: 512,
       timeout: Duration.seconds(10),
@@ -43,7 +43,7 @@ export class TorpinStack extends Stack {
     table.grantReadData(apiLambda);
 
     const eventHandler = new Function(this, 'EventHandlerLambda', {
-      runtime: Runtime.PROVIDED_AL2,
+      runtime: Runtime.PROVIDED_AL2023,
       architecture: Architecture.ARM_64,
       memorySize: 512,
       timeout: Duration.seconds(10),

--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -48,7 +48,7 @@ export class TorpinV2Stack extends Stack {
     table.grantReadData(apiLambda);
 
     const eventHandler = new Function(this, 'EventHandlerLambda', {
-      runtime: Runtime.PROVIDED_AL2,
+      runtime: Runtime.PROVIDED_AL2023,
       architecture: Architecture.ARM_64,
       memorySize: 512,
       timeout: Duration.seconds(10),


### PR DESCRIPTION
## Summary

Updates the Lambda OS-only runtime declarations from Amazon Linux 2 to Amazon Linux 2023.

## Changes

- Migrates both legacy v1 Swift Lambdas in `cdk/lib/torpin-stack.ts` from `Runtime.PROVIDED_AL2` to `Runtime.PROVIDED_AL2023`.
- Migrates the v2 Swift EventBridge handler in `cdk/lib/torpin-v2-stack.ts` from `Runtime.PROVIDED_AL2` to `Runtime.PROVIDED_AL2023`.

## Why

AWS is ending support for the OS-only Amazon Linux 2 Lambda runtime (`provided.al2`). Moving these Swift Lambda functions to `provided.al2023` keeps the stacks on the supported OS-only runtime.

## Validation

- `npm run compile` in `cdk/`
- `swift test` in `lambda/`
- `swift test` in `lambda-v2/`
- Built legacy Lambda archives for `TorpinServiceLambda` and `EventHandlerLambda`
- Built v2 Lambda archive for `EventHandlerV2Lambda`
- Synthesized `TorpinStack`, `TorpinV2StageStack`, and `TorpinV2ProdStack` with AWS CDK and confirmed the Swift Lambda runtimes emit `provided.al2023`

Note: Existing unstaged workflow edits were intentionally left out of this PR.