### PR TITLE
[codex] Serve v2 status from static cache

### DIFF
--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         default: main
 
+env:
+  SWIFT_VERSION: '6.2.1'
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
@@ -23,6 +26,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: ${{ env.SWIFT_VERSION }}
+
       - name: Cache Swift Lambda v2 archive
         id: lambda-v2-cache
         uses: actions/cache@v4
@@ -31,18 +39,6 @@ jobs:
           key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
           restore-keys: |
             swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install API dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Test API Lambda
-        working-directory: ./api
-        run: npm test
-
-      - name: Package API Lambda
-        working-directory: ./api
-        run: npm run package
 
       - name: Test Swift Lambda v2
         working-directory: ./lambda-v2
@@ -86,14 +82,15 @@ jobs:
 
       - name: Bootstrap CDK
         working-directory: ./cdk
-        run: npx cdk bootstrap
+        run: node node_modules/aws-cdk/bin/cdk bootstrap
 
       - name: Deploy v2 prod stack
         env:
+          CLOUDFRONT_CERTIFICATE_ARN: ${{ secrets.CLOUDFRONT_CERTIFICATE_ARN }}
           STEAM_API_KEY: ${{ secrets.STEAM_API_KEY }}
           STEAM_ID: ${{ secrets.STEAM_ID }}
         working-directory: ./cdk
-        run: npx cdk deploy TorpinV2ProdStack --require-approval never --outputs-file cdk-outputs.json
+        run: node node_modules/aws-cdk/bin/cdk deploy TorpinV2ProdStack --require-approval never --outputs-file cdk-outputs.json
 
       - name: Summarize v2 prod deployment
         working-directory: ./cdk
@@ -104,9 +101,10 @@ jobs:
           const summary = [
             '## v2 Prod',
             `- API URL: ${outputs.ApiUrl}`,
+            `- Distribution: ${outputs.DistributionDomainName}`,
             `- Table: ${outputs.TableName}`,
-            `- API Lambda: ${outputs.ApiFunctionName}`,
             `- Event Handler Lambda: ${outputs.EventHandlerFunctionName}`,
+            `- Status Cache Bucket: ${outputs.StatusCacheBucketName}`,
             '',
           ].join('\n');
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
@@ -116,8 +114,15 @@ jobs:
         working-directory: ./cdk
         run: |
           PROD_URL=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2ProdStack; process.stdout.write(outputs.ApiUrl);")
+          EVENT_HANDLER=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2ProdStack; process.stdout.write(outputs.EventHandlerFunctionName);")
+          aws lambda invoke \
+            --function-name "$EVENT_HANDLER" \
+            --cli-binary-format raw-in-base64-out \
+            --payload '{"version":"0","id":"smoke-test","detail-type":"Scheduled Event","source":"aws.events","account":"","time":"2026-01-01T00:00:00Z","region":"us-west-1","resources":[],"detail":{}}' \
+            /tmp/torpin-v2-prod-event-handler.json
+          sleep 10
           RESPONSE=$(curl --fail --silent --show-error "$PROD_URL")
-          RESPONSE="$RESPONSE" node -e "const body = JSON.parse(process.env.RESPONSE); if (typeof body.isBrianTorpin !== 'boolean') process.exit(1); if (!Object.prototype.hasOwnProperty.call(body, 'recentlyTorpedAt')) process.exit(1); if (!Object.prototype.hasOwnProperty.call(body, 'torpedForInSeconds')) process.exit(1);"
+          RESPONSE="$RESPONSE" node -e "const body = JSON.parse(process.env.RESPONSE); const keys = Object.keys(body).sort(); if (keys.length !== 1 || keys[0] !== 'isBrianTorpin') process.exit(1); if (typeof body.isBrianTorpin !== 'boolean') process.exit(1);"
 
       - name: Notify via Pushover
         if: ${{ always() }}

--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Set up Swift
         uses: swift-actions/setup-swift@v3
         with:
+          skip-verify-signature: true
           swift-version: ${{ env.SWIFT_VERSION }}
 
       - name: Cache Swift Lambda v2 archive

--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -17,12 +17,12 @@ jobs:
     environment: production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.git_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache Swift Lambda v2 archive
         id: lambda-v2-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: lambda-v2/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/
           key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
@@ -60,7 +60,7 @@ jobs:
           rm lambda/placeholder.txt
 
       - name: Cache CDK node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: cdk/node_modules
           key: cdk-node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cdk/package-lock.json') }}
@@ -75,7 +75,7 @@ jobs:
         run: npm install -g aws-cdk
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-backend-v2-stage.yaml
+++ b/.github/workflows/deploy-backend-v2-stage.yaml
@@ -18,10 +18,10 @@ jobs:
     environment: staging
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Cache Swift Lambda v2 archive
         id: lambda-v2-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: lambda-v2/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/
           key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
@@ -59,7 +59,7 @@ jobs:
           rm lambda/placeholder.txt
 
       - name: Cache CDK node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: cdk/node_modules
           key: cdk-node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cdk/package-lock.json') }}
@@ -74,7 +74,7 @@ jobs:
         run: npm install -g aws-cdk
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-backend-v2-stage.yaml
+++ b/.github/workflows/deploy-backend-v2-stage.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Set up Swift
         uses: swift-actions/setup-swift@v3
         with:
+          skip-verify-signature: true
           swift-version: ${{ env.SWIFT_VERSION }}
 
       - name: Cache Swift Lambda v2 archive

--- a/.github/workflows/deploy-backend-v2-stage.yaml
+++ b/.github/workflows/deploy-backend-v2-stage.yaml
@@ -6,9 +6,11 @@ on:
       - 'main'
     paths:
       - '.github/workflows/**'
-      - 'api/**'
       - 'lambda-v2/**'
       - 'cdk/**'
+
+env:
+  SWIFT_VERSION: '6.2.1'
 
 jobs:
   deploy:
@@ -23,6 +25,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: ${{ env.SWIFT_VERSION }}
+
       - name: Cache Swift Lambda v2 archive
         id: lambda-v2-cache
         uses: actions/cache@v4
@@ -31,18 +38,6 @@ jobs:
           key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
           restore-keys: |
             swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install API dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Test API Lambda
-        working-directory: ./api
-        run: npm test
-
-      - name: Package API Lambda
-        working-directory: ./api
-        run: npm run package
 
       - name: Test Swift Lambda v2
         working-directory: ./lambda-v2
@@ -86,14 +81,14 @@ jobs:
 
       - name: Bootstrap CDK
         working-directory: ./cdk
-        run: npx cdk bootstrap
+        run: node node_modules/aws-cdk/bin/cdk bootstrap
 
       - name: Deploy v2 stage stack
         env:
           STEAM_API_KEY: ${{ secrets.STEAM_API_KEY }}
           STEAM_ID: ${{ secrets.STEAM_ID }}
         working-directory: ./cdk
-        run: npx cdk deploy TorpinV2StageStack --require-approval never --outputs-file cdk-outputs.json
+        run: node node_modules/aws-cdk/bin/cdk deploy TorpinV2StageStack --require-approval never --outputs-file cdk-outputs.json
 
       - name: Summarize v2 stage deployment
         working-directory: ./cdk
@@ -104,9 +99,10 @@ jobs:
           const summary = [
             '## v2 Stage',
             `- API URL: ${outputs.ApiUrl}`,
+            `- Distribution: ${outputs.DistributionDomainName}`,
             `- Table: ${outputs.TableName}`,
-            `- API Lambda: ${outputs.ApiFunctionName}`,
             `- Event Handler Lambda: ${outputs.EventHandlerFunctionName}`,
+            `- Status Cache Bucket: ${outputs.StatusCacheBucketName}`,
             '',
           ].join('\n');
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
@@ -116,8 +112,15 @@ jobs:
         working-directory: ./cdk
         run: |
           STAGE_URL=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2StageStack; process.stdout.write(outputs.ApiUrl);")
+          EVENT_HANDLER=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2StageStack; process.stdout.write(outputs.EventHandlerFunctionName);")
+          aws lambda invoke \
+            --function-name "$EVENT_HANDLER" \
+            --cli-binary-format raw-in-base64-out \
+            --payload '{"version":"0","id":"smoke-test","detail-type":"Scheduled Event","source":"aws.events","account":"","time":"2026-01-01T00:00:00Z","region":"us-west-1","resources":[],"detail":{}}' \
+            /tmp/torpin-v2-stage-event-handler.json
+          sleep 10
           RESPONSE=$(curl --fail --silent --show-error "$STAGE_URL")
-          RESPONSE="$RESPONSE" node -e "const body = JSON.parse(process.env.RESPONSE); if (typeof body.isBrianTorpin !== 'boolean') process.exit(1); if (!Object.prototype.hasOwnProperty.call(body, 'recentlyTorpedAt')) process.exit(1); if (!Object.prototype.hasOwnProperty.call(body, 'torpedForInSeconds')) process.exit(1);"
+          RESPONSE="$RESPONSE" node -e "const body = JSON.parse(process.env.RESPONSE); const keys = Object.keys(body).sort(); if (keys.length !== 1 || keys[0] !== 'isBrianTorpin') process.exit(1); if (typeof body.isBrianTorpin !== 'boolean') process.exit(1);"
 
       - name: Notify via Pushover
         if: ${{ always() }}

--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -6,7 +6,6 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/**'
-      - 'api/**'
       - 'lambda/**'
       - 'lambda-v2/**'
       - 'cdk/**'
@@ -24,14 +23,6 @@ jobs:
       - name: Install CDK dependencies
         working-directory: ./cdk
         run: npm ci
-
-      - name: Install API dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Package API Lambda
-        working-directory: ./api
-        run: npm run package
 
       - name: Install CDK globally
         run: npm install -g aws-cdk
@@ -51,4 +42,4 @@ jobs:
 
       - name: Synthesize CDK
         working-directory: ./cdk
-        run: npx cdk synth
+        run: node node_modules/aws-cdk/bin/cdk synth

--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -14,9 +14,9 @@ jobs:
   build-cdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/pr-lambda.yaml
+++ b/.github/workflows/pr-lambda.yaml
@@ -6,9 +6,11 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/**'
-      - 'api/**'
       - 'lambda/**'
       - 'lambda-v2/**'
+
+env:
+  SWIFT_VERSION: '6.2.1'
 
 jobs:
   build-lambda:
@@ -16,21 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v3
         with:
-          node-version: '22'
-
-      - name: Install API dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Test API Lambda
-        working-directory: ./api
-        run: npm test
-
-      - name: Package API Lambda
-        working-directory: ./api
-        run: npm run package
+          swift-version: ${{ env.SWIFT_VERSION }}
 
       - name: Test Swift Lambda
         working-directory: ./lambda

--- a/.github/workflows/pr-lambda.yaml
+++ b/.github/workflows/pr-lambda.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Set up Swift
         uses: swift-actions/setup-swift@v3
         with:
+          skip-verify-signature: true
           swift-version: ${{ env.SWIFT_VERSION }}
 
       - name: Test Swift Lambda

--- a/.github/workflows/pr-lambda.yaml
+++ b/.github/workflows/pr-lambda.yaml
@@ -16,7 +16,7 @@ jobs:
   build-lambda:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Swift
         uses: swift-actions/setup-swift@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,19 +4,19 @@
 - `/v1` is the legacy live backend. Keep it running, but do not change it unless the task explicitly calls for legacy `/v1` work.
 - `/v2` is the active backend development target.
 - `GET /v1/` keeps the legacy response contract.
-- `GET /v2` returns `{"isBrianTorpin": boolean, "recentlyTorpedAt": string | null, "torpedForInSeconds": number | null}`.
+- `GET /v2` returns `{"isBrianTorpin": boolean}` from the static status cache.
 
 ## Backend Ownership
 - `lambda/` is the legacy Swift package for `/v1`.
 - `lambda-v2/` is the separate Swift package for the `/v2` EventBridge handler and uses the newer Swift Lambda runtime API.
-- `api/` is the JavaScript Lambda for the `/v2` API.
+- `api/` is the retired JavaScript Lambda package that previously served `/v2`; do not route new `/v2` traffic through it.
 - Do not overlap new `/v2` backend work into existing `/v1` Swift files unless explicitly requested.
 
 ## Infrastructure Ownership
 - `cdk/lib/torpin-stack.ts` owns the legacy `/v1` infrastructure.
 - `cdk/lib/torpin-v2-stack.ts` owns the `/v2` infrastructure.
 - `/v2` has separate `stage` and `prod` environments.
-- `stage` uses the API Gateway execute-api URL only.
+- `stage` uses the CloudFront distribution URL only.
 - `prod` is exposed at `https://api.isbriantorp.in/v2`.
 
 ## Deployment Rules

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy Backend v2 Stage](https://github.com/twistinside/torpin/actions/workflows/deploy-backend-v2-stage.yaml/badge.svg)](https://github.com/twistinside/torpin/actions/workflows/deploy-backend-v2-stage.yaml) [![Deploy Backend v2 Prod](https://github.com/twistinside/torpin/actions/workflows/deploy-backend-v2-prod.yaml/badge.svg)](https://github.com/twistinside/torpin/actions/workflows/deploy-backend-v2-prod.yaml) [![Deploy Website](https://github.com/twistinside/torpin/actions/workflows/deploy-website.yaml/badge.svg)](https://github.com/twistinside/torpin/actions/workflows/deploy-website.yaml)
 
-This project was launched as a learning opportunity, primarily for Swift Lambdas, but also for creating and deploying a full stack project with as much automation as possible. I am very happy with the outcome. The project now runs two backend generations in parallel: legacy `/v1`, and a staged `/v2` rollout that moves the API Lambda to Node.js while keeping the timer-driven Steam polling Lambda in Swift.
+This project was launched as a learning opportunity, primarily for Swift Lambdas, but also for creating and deploying a full stack project with as much automation as possible. I am very happy with the outcome. The project now runs two backend generations in parallel: legacy `/v1`, and a low-latency `/v2` path that serves cached status from S3 through CloudFront while keeping the timer-driven Steam polling Lambda in Swift.
 
 The impetus for this project is my friend's love of World of Warships, and our inside joke that if you check at any particular time of day, he is probably playing. The game is a multiplayer game where you captain a ship and try to sink you opponents, and Torpin' refers to shooting torpedos at the other players.
 
@@ -12,8 +12,8 @@ You can find the site here: https://isbriantorp.in
 
 This project consists of five submodules:
 1. a legacy Swift backend package in `lambda/` that still serves `/v1`
-2. a Node.js API package in `api/` that serves the new `/v2` endpoint
-3. a separate Swift EventBridge Lambda package in `lambda-v2/` that records state for `/v2`
+2. a retired Node.js API package in `api/` that previously served `/v2`
+3. a separate Swift EventBridge Lambda package in `lambda-v2/` that records state for `/v2` and writes the static status cache
 4. a CDK package in `cdk/` that deploys both backend generations
 5. the Astro website in `astro/` that consumes the backend
 
@@ -28,12 +28,12 @@ The live system now has two backend generations:
 1. `v1`
    Keeps the original public endpoint at `https://api.isbriantorp.in/v1/` running unchanged from the legacy Swift package in `lambda/`.
 2. `v2`
-   Adds a parallel backend with separate `stage` and `prod` environments. The `v2` API is served by a Node.js Lambda, and the timer-driven updater runs from the separate `lambda-v2/` Swift package on the current runtime API.
+   Adds a parallel backend with separate `stage` and `prod` environments. The `v2` API is served from a cached S3 object through CloudFront, and the timer-driven updater runs from the separate `lambda-v2/` Swift package on the current runtime API.
 
-Both generations are backed by DynamoDB. `v2` stage and `v2` prod use separate tables so they can be tested independently.
+Both generations are backed by DynamoDB for session history. `v2` stage and `v2` prod use separate tables and status cache buckets so they can be tested independently.
 
 ### Getting Torpin' Status
-The EventBridge trigger fires every minute, triggering a lambda that calls the Steam API to determine if my friend is playing World of Warships. The torpin' status is then stored in DynamoDB as a `Session`. Each `Session` consists of a start and end time. Every `Session` has a start time, and a `Session` is considered active if there is no end time.
+The EventBridge trigger fires every minute, triggering a lambda that calls the Steam API to determine if my friend is playing World of Warships. The torpin' status is then stored in DynamoDB as a `Session` and written to a static S3 cache object for the public `/v2` endpoint. Each `Session` consists of a start and end time. Every `Session` has a start time, and a `Session` is considered active if there is no end time.
 
 If my friend is online and playing World of Warships, the lambda will check for an active `Session`. If none is present, a new one will be created. If he is not online or not playing World of Warships, the lambda will check for an active `Session`. If none is present, nothing is done. If one is found, an end time is added, closing the session.
 
@@ -44,11 +44,9 @@ The API surface is versioned:
 1. `v1`
    When the API is called, the legacy Swift Lambda checks for an active `Session`. If one is found, it returns `{"isBrianTorpin": true}`.
 2. `v2`
-   The new Node.js Lambda reads the newest `sessionRecord` and returns:
+   CloudFront serves a static JSON object written by the v2 updater:
 
-   `{"isBrianTorpin": boolean, "recentlyTorpedAt": string | null, "torpedForInSeconds": number | null}`
-
-   If Brian is currently torpin', `recentlyTorpedAt` is "now" and `torpedForInSeconds` reflects the active session length. If the latest session is closed, `recentlyTorpedAt` is the session end time and `torpedForInSeconds` is the session duration.
+   `{"isBrianTorpin": boolean}`
 
 ### Architecture considerations
 
@@ -89,7 +87,7 @@ Deploying Swift lambdas was as easy as anything in Java land using CDK, and even
 
 I was interested in the difference in cold start times between the compiled Swift code and interpreted Java code. My hope was that loading a binary directly in the runtime would be faster than starting the JVM and loading my code, but I did not find this to be the case. Swift lambda still needs to download the binary, start the lambda runtime, and initialize AWS clients before processing can begin. These steps together are comparatively longer than any improvement caused by moving from interpreted to compiled might provide. Overall, I saw 1 - 1.5 seconds cold start time, which is longer than Java cold start times I've seen, even for comparatively more complex lambdas. AWS puts a lot of time and energy into optimizing Java, and it shows.
 
-Bottom line, Swift lambda is totally workable and ready for use, but a longer lived container architecture would play more to Swift's strengths. I personally love the flexibility and simplicity of the lambda workflow, but cold starts remain a challenge. That tradeoff is the main reason the `/v2` API Lambda moved to Node.js while the scheduled polling Lambda stayed in Swift.
+Bottom line, Swift lambda is totally workable and ready for use, but a longer lived container architecture would play more to Swift's strengths. I personally love the flexibility and simplicity of the lambda workflow, but cold starts remain a challenge. That tradeoff is the main reason the `/v2` read path moved to CloudFront and S3 while the scheduled polling Lambda stayed in Swift.
 
 ## GitHub Actions
 
@@ -99,7 +97,7 @@ Splitting my tasks into the smallest components that I can, then running each on
 
 # Next Steps
 
-At this time, the website still shows a binary torpin'/not torpin', even though `/v2` now exposes richer timing metadata. Pointing the Astro frontend at `/v2` would be a simple way to add more life to the site. "Last seen torpin' 2 days ago!" is a more impactful piece of information than simply "not torpin'".
+At this time, the website still shows a binary torpin'/not torpin'. Pointing the Astro frontend at `/v2` would move it onto the lower-latency cached endpoint while keeping the same boolean display.
 
 The more ambitious expansion is to feed historic data into gen AI and generate commentary about sessions, past, present, and future. A gen AI service could be insturcted to provide commentary, predictions about when the next session might be, and an overview of most played times, for example. This would be a great way to both learn about the next big tech and provide a more delighful experience for visitors to the site.
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,22 +6,23 @@ import { TorpinV2Stack } from '../lib/torpin-v2-stack';
 
 const app = new cdk.App();
 
-new TorpinStack(app, 'TorpinStack', {
+const torpinStack = new TorpinStack(app, 'TorpinStack', {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 
 new TorpinV2Stack(app, 'TorpinV2StageStack', {
-  apiStageName: 'stage',
   environmentName: 'stage',
+  legacyApi: torpinStack.api,
   scheduleEnabled: true,
   tableName: 'TorpinV2Stage',
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 
 new TorpinV2Stack(app, 'TorpinV2ProdStack', {
-  apiStageName: 'prod',
-  customDomainBasePath: 'v2',
+  cloudFrontCertificateArn: process.env.CLOUDFRONT_CERTIFICATE_ARN,
+  customDomainName: 'api.isbriantorp.in',
   environmentName: 'prod',
+  legacyApi: torpinStack.api,
   scheduleEnabled: true,
   tableName: 'TorpinV2Prod',
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },

--- a/cdk/lib/torpin-stack.ts
+++ b/cdk/lib/torpin-stack.ts
@@ -9,6 +9,7 @@ import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 
 export class TorpinStack extends Stack {
+  public readonly api: RestApi;
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
@@ -68,7 +69,7 @@ export class TorpinStack extends Stack {
 
     table.grantReadWriteData(eventHandler);
 
-    const api = new RestApi(this, 'ToprinApiGateway', {
+    this.api = new RestApi(this, 'ToprinApiGateway', {
       restApiName: 'Is Brian Torpin Status Service',
       description: 'This service checks if Brian is playing World of Warships.',
       endpointConfiguration: {
@@ -76,7 +77,7 @@ export class TorpinStack extends Stack {
       },
     });
 
-    const apiResource = api.root.addResource('v1');
+    const apiResource = this.api.root.addResource('v1');
 
     const lambdaIntegration = new LambdaIntegration(apiLambda);
     apiResource.addMethod('GET', lambdaIntegration);
@@ -92,6 +93,6 @@ export class TorpinStack extends Stack {
       endpointType: EndpointType.REGIONAL,  // Ensure it's Regional
     });
 
-    customDomain.addBasePathMapping(api, { basePath: '' });
+    customDomain.addBasePathMapping(this.api, { basePath: '' });
   }
 }

--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -1,16 +1,32 @@
 import { join } from 'path';
 import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import {
+  AllowedMethods,
+  CachePolicy,
+  Distribution,
+  Function as CloudFrontFunction,
+  FunctionCode,
+  FunctionEventType,
+  OriginRequestPolicy,
+  ResponseHeadersPolicy,
+  ViewerProtocolPolicy,
+} from 'aws-cdk-lib/aws-cloudfront';
+import { RestApiOrigin, S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Architecture, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { CfnBasePathMapping, EndpointType, LambdaIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { BucketDeployment, CacheControl, Source } from 'aws-cdk-lib/aws-s3-deployment';
 
 export interface TorpinV2StackProps extends StackProps {
-  apiStageName: string;
-  customDomainBasePath?: string;
+  cloudFrontCertificateArn?: string;
+  customDomainName?: string;
   environmentName: 'prod' | 'stage';
+  legacyApi: RestApi;
   scheduleEnabled: boolean;
   tableName: string;
 }
@@ -27,25 +43,12 @@ export class TorpinV2Stack extends Stack {
       removalPolicy: RemovalPolicy.RETAIN,
     });
 
-    const apiLambda = new Function(this, 'TorpinApi', {
-      runtime: Runtime.NODEJS_22_X,
-      architecture: Architecture.ARM_64,
-      memorySize: 512,
-      timeout: Duration.seconds(10),
-      description: `API lambda for Torpin v2 (${props.environmentName})`,
-      code: Code.fromAsset(
-        join(
-          __dirname,
-          '../../api/.dist'
-        )
-      ),
-      handler: 'index.handler',
-      environment: {
-        TABLE_NAME: table.tableName,
-      },
+    const statusCacheBucket = new Bucket(this, 'StatusCacheBucket', {
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.RETAIN,
     });
-
-    table.grantReadData(apiLambda);
 
     const eventHandler = new Function(this, 'EventHandlerLambda', {
       runtime: Runtime.PROVIDED_AL2023,
@@ -63,6 +66,7 @@ export class TorpinV2Stack extends Stack {
       environment: {
         STEAM_API_KEY: process.env.STEAM_API_KEY || '',
         STEAM_ID: process.env.STEAM_ID || '',
+        STATUS_CACHE_BUCKET: statusCacheBucket.bucketName,
         TABLE_NAME: table.tableName,
       },
     });
@@ -74,37 +78,78 @@ export class TorpinV2Stack extends Stack {
     rule.addTarget(new LambdaFunction(eventHandler));
 
     table.grantReadWriteData(eventHandler);
+    statusCacheBucket.grantPut(eventHandler, 'v2*');
 
-    const api = new RestApi(this, 'TorpinApiGateway', {
-      restApiName: `Is Brian Torpin Status Service v2 (${props.environmentName})`,
-      description: 'This service checks if Brian is playing World of Warships.',
-      endpointConfiguration: {
-        types: [EndpointType.REGIONAL],
+    const normalizeStatusPath = new CloudFrontFunction(this, 'NormalizeStatusPathFunction', {
+      code: FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  if (request.uri === '/v2/') {
+    request.uri = '/v2';
+  }
+  return request;
+}
+      `),
+    });
+    const statusBehavior = {
+      allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+      cachePolicy: CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
+      functionAssociations: [
+        {
+          eventType: FunctionEventType.VIEWER_REQUEST,
+          function: normalizeStatusPath,
+        },
+      ],
+      origin: S3BucketOrigin.withOriginAccessControl(statusCacheBucket),
+      responseHeadersPolicy: ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
+      viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    };
+    const legacyBehavior = {
+      allowedMethods: AllowedMethods.ALLOW_ALL,
+      cachePolicy: CachePolicy.CACHING_DISABLED,
+      origin: new RestApiOrigin(props.legacyApi),
+      originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+      viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    };
+    const cloudFrontCertificate = props.cloudFrontCertificateArn
+      ? Certificate.fromCertificateArn(this, 'CloudFrontCertificate', props.cloudFrontCertificateArn)
+      : undefined;
+    const distribution = new Distribution(this, 'TorpinApiDistribution', {
+      additionalBehaviors: {
+        'v1/*': legacyBehavior,
+        'v2': statusBehavior,
+        'v2/': statusBehavior,
       },
-      deployOptions: {
-        stageName: props.apiStageName,
-      },
+      certificate: cloudFrontCertificate,
+      comment: `Low-latency Torpin API front door (${props.environmentName})`,
+      defaultBehavior: legacyBehavior,
+      domainNames: cloudFrontCertificate && props.customDomainName ? [props.customDomainName] : undefined,
     });
 
-    api.root.addMethod('GET', new LambdaIntegration(apiLambda));
-
-    if (props.customDomainBasePath) {
-      new CfnBasePathMapping(this, 'CustomDomainMapping', {
-        basePath: props.customDomainBasePath,
-        domainName: 'api.isbriantorp.in',
-        restApiId: api.restApiId,
-        stage: api.deploymentStage.stageName,
-      });
-    }
-
-    new CfnOutput(this, 'ApiFunctionName', {
-      value: apiLambda.functionName,
+    new BucketDeployment(this, 'InitialStatusCacheDeployment', {
+      cacheControl: [
+        CacheControl.setPublic(),
+        CacheControl.maxAge(Duration.seconds(60)),
+        CacheControl.sMaxAge(Duration.seconds(60)),
+      ],
+      contentType: 'application/json',
+      destinationBucket: statusCacheBucket,
+      distribution,
+      distributionPaths: ['/v2', '/v2/'],
+      prune: false,
+      sources: [
+        Source.jsonData('v2', { isBrianTorpin: false }),
+      ],
     });
 
     new CfnOutput(this, 'ApiUrl', {
-      value: props.customDomainBasePath
-        ? `https://api.isbriantorp.in/${props.customDomainBasePath}`
-        : api.url,
+      value: cloudFrontCertificate && props.customDomainName
+        ? `https://${props.customDomainName}/v2`
+        : `https://${distribution.distributionDomainName}/v2`,
+    });
+
+    new CfnOutput(this, 'DistributionDomainName', {
+      value: distribution.distributionDomainName,
     });
 
     new CfnOutput(this, 'EventHandlerFunctionName', {
@@ -113,6 +158,10 @@ export class TorpinV2Stack extends Stack {
 
     new CfnOutput(this, 'TableName', {
       value: table.tableName,
+    });
+
+    new CfnOutput(this, 'StatusCacheBucketName', {
+      value: statusCacheBucket.bucketName,
     });
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -8,7 +8,7 @@
     "build": "npm run compile && npm run synth",
     "compile": "npm install && tsc",
     "clean": "rm -rf cdk.out dist node_modules",
-    "synth": "cdk synth"
+    "synth": "node node_modules/aws-cdk/bin/cdk synth"
   },
   "devDependencies": {
     "@types/node": "26.0.1",

--- a/lambda-v2/Package.swift
+++ b/lambda-v2/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
             dependencies: [
                 "Common",
                 .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
+                .product(name: "AWSS3", package: "aws-sdk-swift"),
             ],
             path: "Sources/EventHandlerV2Lambda"
         ),

--- a/lambda-v2/Sources/EventHandlerV2Lambda/EventHandler.swift
+++ b/lambda-v2/Sources/EventHandlerV2Lambda/EventHandler.swift
@@ -1,8 +1,23 @@
 @preconcurrency import AWSDynamoDB
+import AWSS3
 import AWSLambdaEvents
 import AWSLambdaRuntime
 import Common
 import Foundation
+
+protocol RecordTableWriting: Sendable {
+    func add(_ record: TorpinRecord) async throws
+}
+
+protocol SessionManaging: Sendable {
+    func closeActiveSession(at date: Date) async throws
+    func createSession(at date: Date) async throws
+    func hasActiveSession() async throws -> Bool
+}
+
+protocol SteamTorpinChecking: Sendable {
+    func isBrianTorpin() async throws -> Bool
+}
 
 enum EventHandlerAction: Equatable {
     case closeActiveSession
@@ -11,9 +26,10 @@ enum EventHandlerAction: Equatable {
 }
 
 struct EventHandler {
-    let recordTable: RecordTable
-    let sessionManager: SessionManager
-    let steamClient: SteamClient
+    let recordTable: RecordTableWriting
+    let sessionManager: SessionManaging
+    let statusCache: TorpinStatusCaching
+    let steamClient: SteamTorpinChecking
 
     static func action(isTorpin: Bool, hasActiveSession: Bool) -> EventHandlerAction {
         switch (isTorpin, hasActiveSession) {
@@ -35,6 +51,10 @@ struct EventHandler {
         async let active = sessionManager.hasActiveSession()
         let (isTorpin, hasActive) = try await (torpin, active)
 
+        try await updateRecords(isTorpin: isTorpin, hasActiveSession: hasActive, at: date)
+    }
+
+    func updateRecords(isTorpin: Bool, hasActiveSession hasActive: Bool, at date: Date) async throws {
         switch Self.action(isTorpin: isTorpin, hasActiveSession: hasActive) {
         case .closeActiveSession:
             try await sessionManager.closeActiveSession(at: date)
@@ -46,22 +66,33 @@ struct EventHandler {
 
         let torpinRecord = TorpinRecord(date: date, torpin: isTorpin)
         _ = try await recordTable.add(torpinRecord)
+        try await statusCache.putStatus(isBrianTorpin: isTorpin)
     }
 }
 
+extension RecordTable: RecordTableWriting {}
+extension SessionManager: SessionManaging {}
+extension SteamClient: SteamTorpinChecking {}
 extension EventHandler: Sendable {}
 
 @main
 struct EventHandlerV2Lambda {
     private static let region = "us-west-1"
+    private static let statusCacheBucketName = ProcessInfo.processInfo.environment["STATUS_CACHE_BUCKET"] ?? ""
     private static let tableName = ProcessInfo.processInfo.environment["TABLE_NAME"] ?? "Torpin"
 
     static func main() async throws {
-        let config = try await DynamoDBClient.DynamoDBClientConfig(region: self.region)
-        let client = DynamoDBClient(config: config)
+        guard !self.statusCacheBucketName.isEmpty else {
+            throw EventHandlerConfigurationError.missingStatusCacheBucket
+        }
+
+        let dynamoConfig = try await DynamoDBClient.DynamoDBClientConfig(region: self.region)
+        let dynamoClient = DynamoDBClient(config: dynamoConfig)
+        let s3Client = try S3Client(region: self.region)
         let eventHandler = EventHandler(
-            recordTable: RecordTable(client: client, tableName: self.tableName),
-            sessionManager: SessionManager(client: client, tableName: self.tableName),
+            recordTable: RecordTable(client: dynamoClient, tableName: self.tableName),
+            sessionManager: SessionManager(client: dynamoClient, tableName: self.tableName),
+            statusCache: S3TorpinStatusCache(bucketName: self.statusCacheBucketName, s3Client: s3Client),
             steamClient: SteamClient()
         )
         let runtime = LambdaRuntime {
@@ -70,4 +101,8 @@ struct EventHandlerV2Lambda {
         }
         try await runtime.run()
     }
+}
+
+enum EventHandlerConfigurationError: Error {
+    case missingStatusCacheBucket
 }

--- a/lambda-v2/Sources/EventHandlerV2Lambda/TorpinStatusCache.swift
+++ b/lambda-v2/Sources/EventHandlerV2Lambda/TorpinStatusCache.swift
@@ -1,0 +1,50 @@
+import AWSS3
+import Foundation
+import Smithy
+
+protocol S3Putting: Sendable {
+    func putObject(input: PutObjectInput) async throws -> PutObjectOutput
+}
+
+protocol TorpinStatusCaching: Sendable {
+    func putStatus(isBrianTorpin: Bool) async throws
+}
+
+struct TorpinStatusDocument: Encodable, Equatable {
+    let isBrianTorpin: Bool
+}
+
+struct S3TorpinStatusCache {
+    static let cacheControl = "public, max-age=60, s-maxage=60"
+    static let contentType = "application/json"
+    static let keys = ["v2", "v2/"]
+
+    private let bucketName: String
+    private let encoder: JSONEncoder
+    private let s3Client: S3Putting
+
+    init(bucketName: String, s3Client: S3Putting) {
+        self.bucketName = bucketName
+        self.encoder = JSONEncoder()
+        self.s3Client = s3Client
+    }
+
+    func putStatus(isBrianTorpin: Bool) async throws {
+        let document = TorpinStatusDocument(isBrianTorpin: isBrianTorpin)
+        let data = try encoder.encode(document)
+
+        for key in Self.keys {
+            let input = PutObjectInput(
+                body: .data(data),
+                bucket: bucketName,
+                cacheControl: Self.cacheControl,
+                contentType: Self.contentType,
+                key: key
+            )
+            _ = try await s3Client.putObject(input: input)
+        }
+    }
+}
+
+extension S3Client: S3Putting {}
+extension S3TorpinStatusCache: TorpinStatusCaching {}

--- a/lambda-v2/Tests/EventHandlerV2Lambda/EventHandlerTests.swift
+++ b/lambda-v2/Tests/EventHandlerV2Lambda/EventHandlerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Common
 @testable import EventHandlerV2Lambda
 
 final class EventHandlerTests: XCTestCase {
@@ -28,5 +29,57 @@ final class EventHandlerTests: XCTestCase {
             EventHandler.action(isTorpin: true, hasActiveSession: true),
             .noOp
         )
+    }
+
+    func testUpdateRecordsWritesTorpinStatusCache() async throws {
+        let cache = MockStatusCache()
+        let eventHandler = EventHandler(
+            recordTable: MockRecordTable(),
+            sessionManager: MockSessionManager(),
+            statusCache: cache,
+            steamClient: MockSteamClient()
+        )
+
+        try await eventHandler.updateRecords(
+            isTorpin: true,
+            hasActiveSession: false,
+            at: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(cache.statuses, [true])
+    }
+}
+
+private final class MockRecordTable: RecordTableWriting, @unchecked Sendable {
+    func add(_ record: TorpinRecord) async throws {
+        _ = record
+    }
+}
+
+private final class MockSessionManager: SessionManaging, @unchecked Sendable {
+    func closeActiveSession(at date: Date) async throws {
+        _ = date
+    }
+
+    func createSession(at date: Date) async throws {
+        _ = date
+    }
+
+    func hasActiveSession() async throws -> Bool {
+        false
+    }
+}
+
+private final class MockStatusCache: TorpinStatusCaching, @unchecked Sendable {
+    private(set) var statuses: [Bool] = []
+
+    func putStatus(isBrianTorpin: Bool) async throws {
+        statuses.append(isBrianTorpin)
+    }
+}
+
+private final class MockSteamClient: SteamTorpinChecking, @unchecked Sendable {
+    func isBrianTorpin() async throws -> Bool {
+        false
     }
 }

--- a/lambda-v2/Tests/EventHandlerV2Lambda/TorpinStatusCacheTests.swift
+++ b/lambda-v2/Tests/EventHandlerV2Lambda/TorpinStatusCacheTests.swift
@@ -1,0 +1,51 @@
+import AWSS3
+import XCTest
+@testable import EventHandlerV2Lambda
+
+final class TorpinStatusCacheTests: XCTestCase {
+    func testPutStatusWritesBothStaticEndpointObjects() async throws {
+        let s3Client = MockS3Client()
+        let cache = S3TorpinStatusCache(bucketName: "status-bucket", s3Client: s3Client)
+
+        try await cache.putStatus(isBrianTorpin: true)
+
+        XCTAssertEqual(s3Client.inputs.map(\.bucket), ["status-bucket", "status-bucket"])
+        XCTAssertEqual(s3Client.inputs.map(\.cacheControl), [
+            S3TorpinStatusCache.cacheControl,
+            S3TorpinStatusCache.cacheControl,
+        ])
+        XCTAssertEqual(s3Client.inputs.map(\.contentType), [
+            S3TorpinStatusCache.contentType,
+            S3TorpinStatusCache.contentType,
+        ])
+        XCTAssertEqual(s3Client.inputs.map(\.key), S3TorpinStatusCache.keys)
+
+        let bodies = try await s3Client.inputs.asyncMap { input in
+            try await input.body?.readData()
+        }
+        XCTAssertEqual(bodies, [
+            #"{"isBrianTorpin":true}"#.data(using: .utf8),
+            #"{"isBrianTorpin":true}"#.data(using: .utf8),
+        ])
+    }
+}
+
+private final class MockS3Client: S3Putting, @unchecked Sendable {
+    private(set) var inputs: [PutObjectInput] = []
+
+    func putObject(input: PutObjectInput) async throws -> PutObjectOutput {
+        inputs.append(input)
+        return PutObjectOutput()
+    }
+}
+
+private extension Array {
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values: [T] = []
+        for element in self {
+            let value = try await transform(element)
+            values.append(value)
+        }
+        return values
+    }
+}


### PR DESCRIPTION
## Summary
- change `/v2` to a boolean-only static JSON contract served from S3 through CloudFront
- keep the scheduled Swift v2 updater polling Steam and writing cache objects at `v2` and `v2/`
- preserve the legacy v1 stack and route `/v1` through CloudFront to the existing API Gateway origin
- remove obsolete v2 Node API deployment steps while keeping v1 CDK and `lambda/**` workflow triggers active

## Validation
- `swift test` in `lambda-v2`
- `swift test` in `lambda`
- `npm run compile` in `cdk`
- `npm run synth` in `cdk`
- CDK synth for `TorpinStack`, `TorpinV2StageStack`, and `TorpinV2ProdStack`
- `DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --disable-docker-image-update --products EventHandlerV2Lambda`
- `git diff --check`

## Deployment Notes
- prod custom domain alias requires `CLOUDFRONT_CERTIFICATE_ARN` for an ACM certificate in `us-east-1`
- final DNS cutover for `api.isbriantorp.in` remains a manual deployment step
- `api/` source remains in the repository as retired code, but is no longer in the active v2 deploy path