### PR TITLE
[codex] Build Swift Lambda archives on AL2023

### DIFF
--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: lambda-v2/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/
-          key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
+          key: swift-lambda-v2-zip-al2023-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
           restore-keys: |
-            swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-
+            swift-lambda-v2-zip-al2023-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Test Swift Lambda v2
         working-directory: ./lambda-v2
@@ -48,7 +48,7 @@ jobs:
       - name: Package Swift Lambda v2
         if: steps.lambda-v2-cache.outputs.cache-hit != 'true'
         working-directory: ./lambda-v2
-        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --disable-docker-image-update --products EventHandlerV2Lambda
+        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerV2Lambda
 
       - name: Create placeholder legacy Lambda artifacts
         run: |

--- a/.github/workflows/deploy-backend-v2-stage.yaml
+++ b/.github/workflows/deploy-backend-v2-stage.yaml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: lambda-v2/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/
-          key: swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
+          key: swift-lambda-v2-zip-al2023-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lambda-v2/Package.resolved', 'lambda-v2/Sources/**', 'lambda-v2/Package.swift') }}
           restore-keys: |
-            swift-lambda-v2-zip-${{ runner.os }}-${{ runner.arch }}-
+            swift-lambda-v2-zip-al2023-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Test Swift Lambda v2
         working-directory: ./lambda-v2
@@ -47,7 +47,7 @@ jobs:
       - name: Package Swift Lambda v2
         if: steps.lambda-v2-cache.outputs.cache-hit != 'true'
         working-directory: ./lambda-v2
-        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --disable-docker-image-update --products EventHandlerV2Lambda
+        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerV2Lambda
 
       - name: Create placeholder legacy Lambda artifacts
         run: |

--- a/.github/workflows/pr-lambda.yaml
+++ b/.github/workflows/pr-lambda.yaml
@@ -28,9 +28,13 @@ jobs:
         working-directory: ./lambda
         run: swift test
 
-      - name: Package Swift Lambda
+      - name: Package Swift API Lambda
         working-directory: ./lambda
-        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --disable-docker-image-update
+        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products TorpinServiceLambda
+
+      - name: Package Swift Event Handler Lambda
+        working-directory: ./lambda
+        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerLambda
 
       - name: Test Swift Lambda v2
         working-directory: ./lambda-v2
@@ -38,4 +42,4 @@ jobs:
 
       - name: Package Swift Lambda v2
         working-directory: ./lambda-v2
-        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --disable-docker-image-update --products EventHandlerV2Lambda
+        run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerV2Lambda


### PR DESCRIPTION
## Summary
- build Swift Lambda zip artifacts with `swift:amazonlinux2023` so they match `provided.al2023`
- include `al2023` in v2 Lambda archive cache keys so old AL2-built zips are not restored

## Root Cause
The merged stage deploy succeeded, but the smoke test failed because the deployed Swift Lambda exited before startup. CloudWatch logs showed `/var/task/bootstrap: error while loading shared libraries: libcrypto.so.10`, which means the zip was built against Amazon Linux 2/OpenSSL 1.0 while the Lambda runtime is `provided.al2023`.

## Validation
- `ruby -e ... YAML.load_file(...)` for changed workflows
- `npm run compile` in `cdk`
- `npm run synth` in `cdk`
- `git diff --check`
- confirmed `swift:amazonlinux2023` Docker manifest resolves

## Note
Local Docker archive validation could not complete because Docker Desktop ran out of disk while extracting the AL2023 Swift image. The image tag resolved and the command reached Docker image extraction.