### PR TITLE
[codex] Route v2 CloudFront requests to status object

### DIFF
--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -84,8 +84,8 @@ export class TorpinV2Stack extends Stack {
       code: FunctionCode.fromInline(`
 function handler(event) {
   var request = event.request;
-  if (request.uri === '/v2/') {
-    request.uri = '/v2';
+  if (request.uri === '/v2' || request.uri === '/v2/') {
+    request.uri = '/status.json';
   }
   return request;
 }
@@ -138,7 +138,7 @@ function handler(event) {
       distributionPaths: ['/v2', '/v2/'],
       prune: false,
       sources: [
-        Source.jsonData('v2', { isBrianTorpin: false }),
+        Source.jsonData('status.json', { isBrianTorpin: false }),
       ],
     });
 

--- a/lambda-v2/Sources/EventHandlerV2Lambda/TorpinStatusCache.swift
+++ b/lambda-v2/Sources/EventHandlerV2Lambda/TorpinStatusCache.swift
@@ -17,7 +17,7 @@ struct TorpinStatusDocument: Encodable, Equatable {
 struct S3TorpinStatusCache {
     static let cacheControl = "public, max-age=60, s-maxage=60"
     static let contentType = "application/json"
-    static let keys = ["v2", "v2/"]
+    static let keys = ["status.json", "v2", "v2/"]
 
     private let bucketName: String
     private let encoder: JSONEncoder

--- a/lambda-v2/Tests/EventHandlerV2Lambda/TorpinStatusCacheTests.swift
+++ b/lambda-v2/Tests/EventHandlerV2Lambda/TorpinStatusCacheTests.swift
@@ -9,24 +9,25 @@ final class TorpinStatusCacheTests: XCTestCase {
 
         try await cache.putStatus(isBrianTorpin: true)
 
-        XCTAssertEqual(s3Client.inputs.map(\.bucket), ["status-bucket", "status-bucket"])
-        XCTAssertEqual(s3Client.inputs.map(\.cacheControl), [
-            S3TorpinStatusCache.cacheControl,
-            S3TorpinStatusCache.cacheControl,
-        ])
-        XCTAssertEqual(s3Client.inputs.map(\.contentType), [
-            S3TorpinStatusCache.contentType,
-            S3TorpinStatusCache.contentType,
-        ])
+        let expectedCount = S3TorpinStatusCache.keys.count
+        XCTAssertEqual(s3Client.inputs.map(\.bucket), Array(repeating: "status-bucket", count: expectedCount))
+        XCTAssertEqual(
+            s3Client.inputs.map(\.cacheControl),
+            Array(repeating: S3TorpinStatusCache.cacheControl, count: expectedCount)
+        )
+        XCTAssertEqual(
+            s3Client.inputs.map(\.contentType),
+            Array(repeating: S3TorpinStatusCache.contentType, count: expectedCount)
+        )
         XCTAssertEqual(s3Client.inputs.map(\.key), S3TorpinStatusCache.keys)
 
         let bodies = try await s3Client.inputs.asyncMap { input in
             try await input.body?.readData()
         }
-        XCTAssertEqual(bodies, [
-            #"{"isBrianTorpin":true}"#.data(using: .utf8),
-            #"{"isBrianTorpin":true}"#.data(using: .utf8),
-        ])
+        XCTAssertEqual(
+            bodies,
+            Array(repeating: #"{"isBrianTorpin":true}"#.data(using: .utf8), count: expectedCount)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- rewrite `/v2` and `/v2/` CloudFront requests to `/status.json` for the S3 origin
- seed `status.json` in the cache bucket deployment
- have the Swift updater write `status.json` in addition to the compatibility keys `v2` and `v2/`
- update the cache writer test for the extra object write

## Root Cause
Run `28464158799` proved the AL2023 Lambda zip fix worked: the smoke-test Lambda invoke returned `StatusCode: 200` with no `FunctionError`. The remaining failure was CloudFront returning S3 `NotFound` for `/v2` even though the Lambda successfully wrote the `v2` object. Using a conventional `status.json` origin key avoids the ambiguous extensionless/directory-like key path while preserving the public `/v2` contract.

## Validation
- `swift test` in `lambda-v2`
- `npm run compile` in `cdk`
- `npm run synth` in `cdk`
- `git diff --check`