### PR TITLE
Fix v2 status cache permissions

### DIFF
--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -78,6 +78,7 @@ export class TorpinV2Stack extends Stack {
     rule.addTarget(new LambdaFunction(eventHandler));
 
     table.grantReadWriteData(eventHandler);
+    statusCacheBucket.grantPut(eventHandler, 'status.json');
     statusCacheBucket.grantPut(eventHandler, 'v2*');
 
     const normalizeStatusPath = new CloudFrontFunction(this, 'NormalizeStatusPathFunction', {
@@ -117,8 +118,7 @@ function handler(event) {
     const distribution = new Distribution(this, 'TorpinApiDistribution', {
       additionalBehaviors: {
         'v1/*': legacyBehavior,
-        'v2': statusBehavior,
-        'v2/': statusBehavior,
+        'v2*': statusBehavior,
       },
       certificate: cloudFrontCertificate,
       comment: `Low-latency Torpin API front door (${props.environmentName})`,


### PR DESCRIPTION
## Summary
- grant the v2 EventBridge Lambda permission to write the new status.json cache object
- route v2* CloudFront paths through the S3 status behavior so /v2 and /v2/ stay on the static cache path

## Failure observed
Merge deploy run 28471097212 got through deployment but failed the stage smoke test. Manual invoke showed the EventHandler Lambda returned S3 AccessDenied for PutObject on status.json because the existing grant only covered v2*.

## Verification
- npm run compile --prefix cdk
- npm run synth --prefix cdk
- git diff --check