### PR TITLE
Stop forwarding Host to v2 status cache origin

### DIFF
--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -4,7 +4,10 @@ import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
   AllowedMethods,
+  CacheCookieBehavior,
+  CacheHeaderBehavior,
   CachePolicy,
+  CacheQueryStringBehavior,
   Distribution,
   Function as CloudFrontFunction,
   FunctionCode,
@@ -92,9 +95,19 @@ function handler(event) {
 }
       `),
     });
+    const statusCachePolicy = new CachePolicy(this, 'StatusCachePolicy', {
+      cookieBehavior: CacheCookieBehavior.none(),
+      defaultTtl: Duration.seconds(60),
+      enableAcceptEncodingBrotli: true,
+      enableAcceptEncodingGzip: true,
+      headerBehavior: CacheHeaderBehavior.none(),
+      maxTtl: Duration.seconds(60),
+      minTtl: Duration.seconds(0),
+      queryStringBehavior: CacheQueryStringBehavior.none(),
+    });
     const statusBehavior = {
       allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
-      cachePolicy: CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
+      cachePolicy: statusCachePolicy,
       functionAssociations: [
         {
           eventType: FunctionEventType.VIEWER_REQUEST,


### PR DESCRIPTION
## Summary
- keep the private S3 status cache origin on CloudFront OAC
- replace the managed status cache policy with a dedicated policy that forwards no headers, cookies, or query strings
- keep the status cache TTL bounded at 60 seconds

## Failure observed
Merge deploy run 28472911312 completed CDK deploy and invoked the EventHandler Lambda successfully, but the stage smoke test still got a 404 from S3 through CloudFront.

Direct checks showed:
- the Lambda wrote fresh status.json and v2 objects to the stage bucket
- the deployed distribution selected the S3 behavior for v2*
- the deployed managed cache policy forwarded the viewer Host header to the S3 origin

Forwarding Host to an S3 origin is the stronger root-cause candidate: S3 expects the bucket host, not d201dma72vg35v.cloudfront.net or api.isbriantorp.in. This patch removes Host forwarding for the static status behavior while leaving v1/API Gateway forwarding unchanged.

## Verification
- npm run compile --prefix cdk
- npm run synth --prefix cdk
- synthesized stage template has a custom status CachePolicy with HeadersConfig/HeaderBehavior none
- git diff --check