### PR TITLE
Smoke test prod CloudFront distribution URL

### DIFF
--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Smoke test v2 prod API
         working-directory: ./cdk
         run: |
-          PROD_URL=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2ProdStack; process.stdout.write(outputs.ApiUrl);")
+          PROD_URL=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2ProdStack; process.stdout.write('https://' + outputs.DistributionDomainName + '/v2');")
           EVENT_HANDLER=$(node -e "const fs = require('fs'); const outputs = JSON.parse(fs.readFileSync('cdk-outputs.json', 'utf8')).TorpinV2ProdStack; process.stdout.write(outputs.EventHandlerFunctionName);")
           aws lambda invoke \
             --function-name "$EVENT_HANDLER" \


### PR DESCRIPTION
## Summary
- make the prod v2 smoke test call the deployed CloudFront distribution domain from stack outputs
- avoid testing api.isbriantorp.in before manual DNS cutover has pointed it at the new distribution

## Why
The prod stack can expose ApiUrl as https://api.isbriantorp.in/v2 when CLOUDFRONT_CERTIFICATE_ARN is configured. Before DNS cutover, that hostname still points at the legacy API Gateway and would fail the prod smoke test even if the new CloudFront distribution works.

## Verification
- parsed .github/workflows/deploy-backend-v2-prod.yaml as YAML
- locally simulated the node expression used to build the smoke-test URL
- git diff --check