### PR TITLE
Decouple v2 CloudFront from legacy stack

### DIFF
--- a/.github/workflows/deploy-backend-v2-prod.yaml
+++ b/.github/workflows/deploy-backend-v2-prod.yaml
@@ -50,15 +50,6 @@ jobs:
         working-directory: ./lambda-v2
         run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerV2Lambda
 
-      - name: Create placeholder legacy Lambda artifacts
-        run: |
-          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda
-          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda
-          echo 'placeholder' > lambda/placeholder.txt
-          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda/TorpinServiceLambda.zip lambda/placeholder.txt
-          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda/EventHandlerLambda.zip lambda/placeholder.txt
-          rm lambda/placeholder.txt
-
       - name: Cache CDK node_modules
         uses: actions/cache@v6
         with:

--- a/.github/workflows/deploy-backend-v2-stage.yaml
+++ b/.github/workflows/deploy-backend-v2-stage.yaml
@@ -49,15 +49,6 @@ jobs:
         working-directory: ./lambda-v2
         run: DOCKER_DEFAULT_PLATFORM=linux/arm64 swift package --disable-sandbox --allow-network-connections docker archive --base-docker-image swift:amazonlinux2023 --disable-docker-image-update --products EventHandlerV2Lambda
 
-      - name: Create placeholder legacy Lambda artifacts
-        run: |
-          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda
-          mkdir -p lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda
-          echo 'placeholder' > lambda/placeholder.txt
-          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/TorpinServiceLambda/TorpinServiceLambda.zip lambda/placeholder.txt
-          zip -qj lambda/.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/EventHandlerLambda/EventHandlerLambda.zip lambda/placeholder.txt
-          rm lambda/placeholder.txt
-
       - name: Cache CDK node_modules
         uses: actions/cache@v6
         with:

--- a/.github/workflows/pr-cdk.yaml
+++ b/.github/workflows/pr-cdk.yaml
@@ -41,5 +41,7 @@ jobs:
           rm lambda-v2/placeholder.txt
 
       - name: Synthesize CDK
+        env:
+          INCLUDE_LEGACY_STACK: 'true'
         working-directory: ./cdk
         run: node node_modules/aws-cdk/bin/cdk synth

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,13 +6,19 @@ import { TorpinV2Stack } from '../lib/torpin-v2-stack';
 
 const app = new cdk.App();
 
-const torpinStack = new TorpinStack(app, 'TorpinStack', {
-  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-});
+if (process.env.INCLUDE_LEGACY_STACK === 'true') {
+  new TorpinStack(app, 'TorpinStack', {
+    env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  });
+}
+
+const legacyApiDomainName = process.env.LEGACY_API_DOMAIN_NAME ?? 'h3ewqpnbxc.execute-api.us-west-1.amazonaws.com';
+const legacyApiOriginPath = process.env.LEGACY_API_ORIGIN_PATH ?? '/prod';
 
 new TorpinV2Stack(app, 'TorpinV2StageStack', {
   environmentName: 'stage',
-  legacyApi: torpinStack.api,
+  legacyApiDomainName,
+  legacyApiOriginPath,
   scheduleEnabled: true,
   tableName: 'TorpinV2Stage',
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
@@ -22,7 +28,8 @@ new TorpinV2Stack(app, 'TorpinV2ProdStack', {
   cloudFrontCertificateArn: process.env.CLOUDFRONT_CERTIFICATE_ARN,
   customDomainName: 'api.isbriantorp.in',
   environmentName: 'prod',
-  legacyApi: torpinStack.api,
+  legacyApiDomainName,
+  legacyApiOriginPath,
   scheduleEnabled: true,
   tableName: 'TorpinV2Prod',
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },

--- a/cdk/lib/torpin-stack.ts
+++ b/cdk/lib/torpin-stack.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Architecture, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { DomainName, EndpointType, LambdaIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -81,6 +81,16 @@ export class TorpinStack extends Stack {
 
     const lambdaIntegration = new LambdaIntegration(apiLambda);
     apiResource.addMethod('GET', lambdaIntegration);
+
+    new CfnOutput(this, 'ExportsOutputRefToprinApiGatewayCAC85CDFD3277779', {
+      exportName: 'TorpinStack:ExportsOutputRefToprinApiGatewayCAC85CDFD3277779',
+      value: this.api.restApiId,
+    });
+
+    new CfnOutput(this, 'ExportsOutputRefToprinApiGatewayDeploymentStageprod8AAE6324E7284805', {
+      exportName: 'TorpinStack:ExportsOutputRefToprinApiGatewayDeploymentStageprod8AAE6324E7284805',
+      value: this.api.deploymentStage.stageName,
+    });
 
     const certificate = new Certificate(this, 'Certificate', {
       domainName: 'api.isbriantorp.in',

--- a/cdk/lib/torpin-v2-stack.ts
+++ b/cdk/lib/torpin-v2-stack.ts
@@ -16,9 +16,8 @@ import {
   ResponseHeadersPolicy,
   ViewerProtocolPolicy,
 } from 'aws-cdk-lib/aws-cloudfront';
-import { RestApiOrigin, S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { HttpOrigin, S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Architecture, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
@@ -29,7 +28,8 @@ export interface TorpinV2StackProps extends StackProps {
   cloudFrontCertificateArn?: string;
   customDomainName?: string;
   environmentName: 'prod' | 'stage';
-  legacyApi: RestApi;
+  legacyApiDomainName: string;
+  legacyApiOriginPath: string;
   scheduleEnabled: boolean;
   tableName: string;
 }
@@ -121,7 +121,9 @@ function handler(event) {
     const legacyBehavior = {
       allowedMethods: AllowedMethods.ALLOW_ALL,
       cachePolicy: CachePolicy.CACHING_DISABLED,
-      origin: new RestApiOrigin(props.legacyApi),
+      origin: new HttpOrigin(props.legacyApiDomainName, {
+        originPath: props.legacyApiOriginPath,
+      }),
       originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
       viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
     };


### PR DESCRIPTION
## Summary
- make the v2 CloudFront legacy origin use the existing API Gateway execute-api domain/path directly
- stop default CDK synthesis from instantiating `TorpinStack` unless `INCLUDE_LEGACY_STACK=true`
- remove placeholder legacy Lambda artifacts from v2 stage/prod deploy workflows
- keep legacy stack synthesis covered in the PR CDK workflow and preserve existing legacy API Gateway exports explicitly

## Why
The v2 CloudFront distribution used `RestApiOrigin(props.legacyApi)`, which required constructing `TorpinStack` during v2 deploys. Because the v2 workflows created placeholder legacy Lambda zips only to satisfy synthesis, those deploys updated the live v1 Lambdas with invalid placeholder artifacts.

## Immediate remediation already performed
- rebuilt real legacy Swift Lambda zips against `swift:amazonlinux2023`
- deployed `TorpinStack`
- verified `https://api.isbriantorp.in/v1/`, raw API Gateway `/prod/v1/`, and prod CloudFront `/v1/` all return 200 again

## Verification
- `npm run compile --prefix cdk`
- `node node_modules/aws-cdk/bin/cdk synth TorpinV2StageStack`
- `INCLUDE_LEGACY_STACK=true node node_modules/aws-cdk/bin/cdk synth TorpinStack`
- `node node_modules/aws-cdk/bin/cdk list` shows only v2 stacks by default
- `INCLUDE_LEGACY_STACK=true node node_modules/aws-cdk/bin/cdk list` includes TorpinStack
- parsed edited workflow YAML files
- `git diff --check`
